### PR TITLE
Fix crash if a subAdapter removes all items

### DIFF
--- a/recyclerviewmergeadapter/src/main/java/me/mvdw/recyclerviewmergeadapter/adapter/RecyclerViewMergeAdapter.java
+++ b/recyclerviewmergeadapter/src/main/java/me/mvdw/recyclerviewmergeadapter/adapter/RecyclerViewMergeAdapter.java
@@ -252,7 +252,7 @@ public class RecyclerViewMergeAdapter extends RecyclerView.Adapter {
         for (LocalAdapter localAdapter : mAdapters) {
             RecyclerView.Adapter adapter_ = localAdapter.mAdapter;
 
-            if (adapter_.equals(adapter) && adapter_.getItemCount() > 0) {
+            if (adapter_.equals(adapter)) {
                 return count;
             }
 


### PR DESCRIPTION
There was a problem when removing all items in a subAdapter.
```
java.lang.IllegalArgumentException: Called attach on a child which is not detached: ViewHolder{94331c4 position=0 id=-1, oldPos=-1, pLpos:-1} android.support.v7.widget.RecyclerView{c5e18ad VFED..... ......ID 21,114-1059,662 #7f090128 app:id/users}, adapter:me.mvdw.recyclerviewmergeadapter.adapter.RecyclerViewMergeAdapter@26367e2
```

When debugging I found out, that the error was in getSubAdapterFirstGlobalPosition which returned -1 when called from the observer in onItemRangeRemoved. That of course messes stuff up. So I removed the check which checks for more than 0 items. I wonder why that expression was in there anyway. At least that fixed the bug for me and everything works fine again :).

Temporary workaround before release (for those searching):
```
public class FixedRecyclerViewMergeAdapter extends RecyclerViewMergeAdapter {
    public int getSubAdapterFirstGlobalPosition(RecyclerView.Adapter adapter) {
        int count = 0;

        for (LocalAdapter localAdapter : mAdapters) {
            RecyclerView.Adapter adapter_ = localAdapter.mAdapter;

            if (adapter_.equals(adapter)) {
                return count;
            }

            count += adapter_.getItemCount();
        }

        return -1;
    }
}
```