### PR TITLE
Fix/subadapter empty crash

### DIFF
--- a/recyclerviewmergeadapter/build.gradle
+++ b/recyclerviewmergeadapter/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'com.jfrog.bintray'
 
 group = 'me.mvdw.recyclerviewmergeadapter'
-version = "2.1.0"
+version = "2.1.1"
 
 def siteUrl = 'https://github.com/martijnvdwoude/recycler-view-merge-adapter'
 def gitUrl = 'https://github.com/martijnvdwoude/recycler-view-merge-adapter.git'
@@ -16,7 +16,7 @@ android {
     defaultConfig {
         minSdkVersion 14
         targetSdkVersion 29
-        versionCode 2
+        versionCode 3
         versionName version
     }
 

--- a/recyclerviewmergeadapter/build.gradle
+++ b/recyclerviewmergeadapter/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'com.jfrog.bintray'
 
 group = 'me.mvdw.recyclerviewmergeadapter'
-version = "2.1.1"
+version = "2.1.2"
 
 def siteUrl = 'https://github.com/martijnvdwoude/recycler-view-merge-adapter'
 def gitUrl = 'https://github.com/martijnvdwoude/recycler-view-merge-adapter.git'
@@ -16,7 +16,7 @@ android {
     defaultConfig {
         minSdkVersion 14
         targetSdkVersion 29
-        versionCode 3
+        versionCode 4
         versionName version
     }
 

--- a/recyclerviewmergeadapter/src/main/java/me/mvdw/recyclerviewmergeadapter/adapter/RecyclerViewMergeAdapter.java
+++ b/recyclerviewmergeadapter/src/main/java/me/mvdw/recyclerviewmergeadapter/adapter/RecyclerViewMergeAdapter.java
@@ -29,25 +29,25 @@ public class RecyclerViewMergeAdapter extends RecyclerView.Adapter {
 
         @Override
         public void onItemRangeChanged(int positionStart, int itemCount) {
-            int subAdapterOffset = getSubAdapterFirstGlobalPosition(mAdapter);
+            int subAdapterOffset = getSubAdapterFirstGlobalPositionEvenIfEmpty(mAdapter);
             RecyclerViewMergeAdapter.this.notifyItemRangeChanged(subAdapterOffset + positionStart, itemCount);
         }
 
         @Override
         public void onItemRangeInserted(int positionStart, int itemCount) {
-            int subAdapterOffset = getSubAdapterFirstGlobalPosition(mAdapter);
+            int subAdapterOffset = getSubAdapterFirstGlobalPositionEvenIfEmpty(mAdapter);
             RecyclerViewMergeAdapter.this.notifyItemRangeInserted(subAdapterOffset + positionStart, itemCount);
         }
 
         @Override
         public void onItemRangeMoved(int fromPosition, int toPosition, int itemCount) {
-            int subAdapterOffset = getSubAdapterFirstGlobalPosition(mAdapter);
+            int subAdapterOffset = getSubAdapterFirstGlobalPositionEvenIfEmpty(mAdapter);
             RecyclerViewMergeAdapter.this.notifyItemMoved(subAdapterOffset + fromPosition, subAdapterOffset + toPosition);
         }
 
         @Override
         public void onItemRangeRemoved(int positionStart, int itemCount) {
-            int subAdapterOffset = getSubAdapterFirstGlobalPosition(mAdapter);
+            int subAdapterOffset = getSubAdapterFirstGlobalPositionEvenIfEmpty(mAdapter);
             RecyclerViewMergeAdapter.this.notifyItemRangeRemoved(subAdapterOffset + positionStart, itemCount);
         }
 
@@ -240,19 +240,20 @@ public class RecyclerViewMergeAdapter extends RecyclerView.Adapter {
         return null;
     }
 
+
     /**
      * Return the first global position in the entire set of items for a given adapter.
      *
      * @param adapter The adapter for which to the return the first global position.
      * @return The first global position for the given adapter, or -1 if no such position could be found.
      */
-    public int getSubAdapterFirstGlobalPosition(RecyclerView.Adapter adapter) {
+    private int getSubAdapterFirstGlobalPositionInternal(RecyclerView.Adapter adapter, Boolean evenIfEmpty) {
         int count = 0;
 
         for (LocalAdapter localAdapter : mAdapters) {
             RecyclerView.Adapter adapter_ = localAdapter.mAdapter;
 
-            if (adapter_.equals(adapter) && adapter_.getItemCount() > 0) {
+            if (adapter_.equals(adapter) && (evenIfEmpty || adapter_.getItemCount() > 0)) {
                 return count;
             }
 
@@ -261,6 +262,16 @@ public class RecyclerViewMergeAdapter extends RecyclerView.Adapter {
 
         return -1;
     }
+
+    public int getSubAdapterFirstGlobalPositionEvenIfEmpty(RecyclerView.Adapter adapter) {
+        return getSubAdapterFirstGlobalPositionInternal(adapter, true);
+    }
+
+    public int getSubAdapterFirstGlobalPosition(RecyclerView.Adapter adapter) {
+        return getSubAdapterFirstGlobalPositionInternal(adapter, false);
+    }
+
+
 
     @Override
     public void onBindViewHolder(RecyclerView.ViewHolder viewHolder, int position) {

--- a/recyclerviewmergeadapter/src/main/java/me/mvdw/recyclerviewmergeadapter/adapter/RecyclerViewMergeAdapter.java
+++ b/recyclerviewmergeadapter/src/main/java/me/mvdw/recyclerviewmergeadapter/adapter/RecyclerViewMergeAdapter.java
@@ -247,7 +247,7 @@ public class RecyclerViewMergeAdapter extends RecyclerView.Adapter {
      * @param adapter The adapter for which to the return the first global position.
      * @return The first global position for the given adapter, or -1 if no such position could be found.
      */
-    private int getSubAdapterFirstGlobalPositionInternal(RecyclerView.Adapter adapter, Boolean evenIfEmpty) {
+    private int getSubAdapterFirstGlobalPositionInternal(RecyclerView.Adapter adapter, boolean evenIfEmpty) {
         int count = 0;
 
         for (LocalAdapter localAdapter : mAdapters) {
@@ -270,7 +270,6 @@ public class RecyclerViewMergeAdapter extends RecyclerView.Adapter {
     public int getSubAdapterFirstGlobalPosition(RecyclerView.Adapter adapter) {
         return getSubAdapterFirstGlobalPositionInternal(adapter, false);
     }
-
 
 
     @Override


### PR DESCRIPTION
The library crashes when a sub-adapter is cleared of items, and that was caused because when data is changing the global position would be -1, and that would mess up the work of `notifyItemRangeRemoved` function, and lead to a crash,

solution: created a new function which will return the first global position of the sub-adapter even if it is empty, which means the function will return the position-to-be i.e in case the adapter has at least one item this the position it will be at. 